### PR TITLE
change key to tag; add actual keyboard shortcuts; add menu item validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ end
 
 ### Keyboard shortcuts
 
-Assign keyboard shortcuts to menu items. Takes a string of the form '(_modifier_+)*_character' where _modifier is any of: shift, alt, alternate, command, cmd, control, ctrl, ctl.
+Assign keyboard shortcuts to menu items. Takes a string of the form '(_modifier_+)*character' where _modifier_ is any of: shift, alt, alternate, command, cmd, control, ctrl, ctl.
 
 ```ruby
 menu = MenuMotion::Menu.new({
@@ -164,6 +164,7 @@ menu = MenuMotion::Menu.new({
     }]
   }]
 })
+```
 
 ### Menu Item validation
 

--- a/README.md
+++ b/README.md
@@ -140,37 +140,84 @@ def action_with_sender(sender)
 end
 ```
 
-### Updating Menu Items
+### Keyboard shortcuts
 
-Assign keys to menu items that will need to be updated.
+Assign keyboard shortcuts to menu items. Takes a string of the form '(_modifier_+)*_character' where _modifier is any of: shift, alt, alternate, command, cmd, control, ctrl, ctl.
 
 ```ruby
 menu = MenuMotion::Menu.new({
   rows: [{
     title: "Menu item",
-    key: :main_item
+    tag: :main_item
     rows: [{
       title: "Submenu item 1",
-      key: :submenu_item1,
+      tag: :submenu_item1,
+      target: self,
+      action: "do_something:",
+      shortcut: "cmd+1"
+    }, {
+      title: "Submenu item 2",
+      tag: :submenu_item2,
+      target: self,
+      action: "do_something:"
+      shortcut: "shift+cmd+2"
+    }]
+  }]
+})
+
+### Menu Item validation
+
+MenuMotion implements the [NSMenuValidation](https://developer.apple.com/library/mac/documentation/cocoa/reference/applicationkit/Protocols/NSMenuValidation_Protocol/Reference/Reference.html) protocol. Pass a method name or a proc to a menu item:
+
+```ruby
+menu = MenuMotion::Menu.new({
+  rows: [{
+    title: "Menu item",
+    tag: :main_item
+    rows: [{
+      title: "Submenu item 1",
+      tag: :submenu_item1,
+      target: self,
+      action: "do_something:",
+      validate: ->(menu_item) {
+        true
+      }
+    }]
+  }]
+})
+```
+
+### Reconfiguring Menu Items
+
+Assign tags to menu items that will need to be reconfigured.
+
+```ruby
+menu = MenuMotion::Menu.new({
+  rows: [{
+    title: "Menu item",
+    tag: :main_item
+    rows: [{
+      title: "Submenu item 1",
+      tag: :submenu_item1,
       target: self,
       action: "do_something:"
     }, {
       title: "Submenu item 2",
-      key: :submenu_item2,
+      tag: :submenu_item2,
       target: self,
       action: "do_something:"
     }]
   }]
 })
 
-# Let's update the first item's title:
-menu.update(:main_item, {
+# Let's reconfigure the first item's title:
+menu.reconfigure(:main_item, {
   title: "Hello World"
 })
 
 # And give the first submenu item a submenu.
 # The target and action will not be used if a submenu is defined.
-menu.update(:submenu_item1, {
+menu.reconfigure(:submenu_item1, {
   rows: [{
     title: "Click me",
     target: self,
@@ -182,7 +229,6 @@ menu.update(:submenu_item1, {
 ## TODO
 
 - Menu Item Icons
-- Keyboard Shortcuts
 
 ## Contributing
 

--- a/lib/menu_motion/menu.rb
+++ b/lib/menu_motion/menu.rb
@@ -39,12 +39,12 @@ module MenuMotion
           menu_item.tag = tag
         end
 
-        if (ke=row[:key])
-          parts = ke.split('-')
+        if (ke=row[:shortcut])
+          parts = ke.split('+')
           k = parts.pop
 
-          raise MMException.new("Missing key char for menu item #{menu_item.title}: #{ke}") unless (k)
-          raise MMException.new("Unknown key char for menu item #{menu_item.title}: #{ke}") unless (k.length == 1)
+          raise MMException.new("Missing key char for menu item #{menu_item.title} shortcut: #{ke}") unless (k)
+          raise MMException.new("Unknown key char for menu item #{menu_item.title} shortcut: #{ke}") unless (k.length == 1)
 
           mod_mask = parts.inject(0) do |mask,mod|
             case mod
@@ -57,7 +57,7 @@ module MenuMotion
             when 'control', 'ctl', 'ctrl'
               mask |= NSControlKeyMask
             else
-              raise MMException.new("Unknown key modifier for menu item #{menu_item.title}: #{mod.to_s}. Want any of shift, alt, alternate, command, cmd, control, ctrl, ctl")
+              raise MMException.new("Unknown key modifier for menu item #{menu_item.title} shortcut: #{mod.to_s}. Want any of: shift, alt, alternate, command, cmd, control, ctrl, ctl")
             end
 
             mask
@@ -110,7 +110,7 @@ module MenuMotion
       @menu_items[tag.to_sym]
     end
 
-    def reconfig(tag, params)
+    def reconfigure(tag, params)
       menu_item = self.item_with_tag(tag)
 
       [
@@ -119,7 +119,7 @@ module MenuMotion
        :action,
        :validate,
        :tag,
-       :key,
+       :shortcut,
        :enabled
       ].each do |f|
         menu_item.send("#{f}=",params[f]) if (params.has_key?(f))

--- a/lib/menu_motion/menu.rb
+++ b/lib/menu_motion/menu.rb
@@ -4,37 +4,75 @@ module MenuMotion
 
     attr_accessor :menu_items
     attr_accessor :root_menu
+    attr_accessor :tag
 
     def add_rows_to_menu(menu, rows)
       rows.each do |row|
-        menu_item = NSMenuItem.alloc.initWithTitle(row[:title], action: row[:action], keyEquivalent:"")
-        menu_item.target = row[:target]
+        menu_item = MenuMotion::MenuItem.new(row[:title], row[:target], row[:action], row[:validate])
+        menu_item.target = self
+        menu_item.action = '_menu_item_action:'
 
         # Add sections and/or rows to a submenu
         if row[:sections]
           submenu = MenuMotion::Menu.new({
-            sections: row[:sections]
-          }, self.root_menu || self)
+                                           sections: row[:sections]
+                                         }, self.root_menu || self)
           menu_item.setSubmenu(submenu)
         elsif row[:rows]
           submenu = MenuMotion::Menu.new({
-            rows: row[:rows]
-          }, self.root_menu || self)
+                                           rows: row[:rows]
+                                         }, self.root_menu || self)
           menu_item.setSubmenu(submenu)
         end
 
-        if row[:key]
+        if (tag=row[:tag])
+          tag = tag.to_sym
+
           if self.root_menu
             self.root_menu.menu_items ||= {}
-            self.root_menu.menu_items[row[:key].to_sym] = WeakRef.new(menu_item)
+            self.root_menu.menu_items[tag] = WeakRef.new(menu_item)
           else
             self.menu_items ||= {}
-            self.menu_items[row[:key].to_sym] = WeakRef.new(menu_item)
+            self.menu_items[tag] = WeakRef.new(menu_item)
           end
+
+          menu_item.tag = tag
+        end
+
+        if (ke=row[:key])
+          parts = ke.split('-')
+          k = parts.pop
+
+          raise MMException.new("Missing key char for menu item #{menu_item.title}: #{ke}") unless (k)
+          raise MMException.new("Unknown key char for menu item #{menu_item.title}: #{ke}") unless (k.length == 1)
+
+          mod_mask = parts.inject(0) do |mask,mod|
+            case mod
+            when 'shift'
+              mask |= NSShiftKeyMask
+            when 'alt', 'alternate'
+              mask |= NSAlternateKeyMask
+            when 'command', 'cmd'
+              mask |= NSCommandKeyMask
+            when 'control', 'ctl', 'ctrl'
+              mask |= NSControlKeyMask
+            else
+              raise MMException.new("Unknown key modifier for menu item #{menu_item.title}: #{mod.to_s}. Want any of shift, alt, alternate, command, cmd, control, ctrl, ctl")
+            end
+
+            mask
+          end
+
+          menu_item.setKeyEquivalent(k)
+          menu_item.setKeyEquivalentModifierMask(mod_mask)
         end
 
         menu.addItem(menu_item)
       end
+    end
+
+    def validateMenuItem(menu_item)
+      menu_item.validate
     end
 
     def add_sections_to_menu(menu, sections)
@@ -59,7 +97,7 @@ module MenuMotion
     end
 
     def initialize(params = {}, root_menu = nil)
-      super()
+      initWithTitle(params[:title] || 'Add A Title!')
 
       self.root_menu = root_menu
       self.build_menu_from_params(self, params)
@@ -67,22 +105,75 @@ module MenuMotion
       self
     end
 
-    def item_with_key(key)
+    def item_with_tag(tag)
       @menu_items ||= {}
-      @menu_items[key.to_sym]
+      @menu_items[tag.to_sym]
     end
 
-    def update(key, params)
-      menu_item = self.item_with_key(key)
+    def reconfig(tag, params)
+      menu_item = self.item_with_tag(tag)
 
-      menu_item.title  = params[:title]  if params[:title]
-      menu_item.target = params[:target] if params[:target]
-      menu_item.action = params[:action] if params[:action]
+      [
+       :title,
+       :target,
+       :action,
+       :validate,
+       :tag,
+       :key,
+       :enabled
+      ].each do |f|
+        menu_item.send("#{f}=",params[f]) if (params.has_key?(f))
+      end
 
       self
     end
 
+    def _menu_item_action(menu_item)
+      menu_item.act
+    end
+
   end
 
+  class MenuItem < NSMenuItem
+
+    attr_accessor :tag
+
+    def initialize(title, target, action, validate)
+      initWithTitle(title, action: nil, keyEquivalent: '')
+
+      @mi_validate = validate
+      @mi_target = target
+      @mi_action = action
+      self
+    end
+
+    def act
+      target = @mi_target || NSApp
+
+      if (@mi_action)
+        if (target.class.instance_method(@mi_action).arity == 0)
+          target.send(@mi_action) 
+        else
+          target.send(@mi_action,self)
+        end
+      end
+    end
+
+    def validate
+      if (@mi_validate.kind_of?(Proc))
+        return true unless (@mi_validate)
+
+        @mi_validate.call(self)
+      else
+        return true unless (@mi_validate && @mi_target)
+
+        @mi_target.send(@mi_validate,self)
+      end
+    end
+
+  end
+
+  class MMException < ::Exception
+  end
 end
 

--- a/spec/menu_motion/menu_spec.rb
+++ b/spec/menu_motion/menu_spec.rb
@@ -135,71 +135,71 @@ describe "MenuMotion::Menu" do
     menu_item.submenu.itemAtIndex(3).title.should.equal "Section 2 Row 1"
   end
 
-  it "#item_with_key returns menu items by the lookup key" do
+  it "#item_with_tag returns menu items by the lookup tag" do
     menu = MenuMotion::Menu.new({
       rows: [{
         title: "Menu item",
-        key: :main_item,
+        tag: :main_item,
         sections: [{
           rows: [{
             title: "Section 1 Row 1",
-            key: :section1_row1
+            tag: :section1_row1
           }, {
             title: "Section 1 Row 2",
-            key: :section1_row2
+            tag: :section1_row2
           }]
         }, {
           rows: [{
             title: "Section 2 Row 1",
-            key: :section2_row1
+            tag: :section2_row1
           }]
         }]
       }]
     })
 
-    item = menu.item_with_key(:main_item)
+    item = menu.item_with_tag(:main_item)
     item.title.should.equal "Menu item"
 
-    item = menu.item_with_key(:section1_row1)
+    item = menu.item_with_tag(:section1_row1)
     item.title.should.equal "Section 1 Row 1"
 
-    item = menu.item_with_key(:section1_row2)
+    item = menu.item_with_tag(:section1_row2)
     item.title.should.equal "Section 1 Row 2"
 
-    item = menu.item_with_key(:section2_row1)
+    item = menu.item_with_tag(:section2_row1)
     item.title.should.equal "Section 2 Row 1"
   end
 
-  it "Updates the title of the menu item with the given key" do
+  it "Reconfigures the title of the menu item with the given tag" do
     menu = MenuMotion::Menu.new({
       rows: [{
         title: "Menu item",
-        key: :main_item,
+        tag: :main_item,
         sections: [{
           rows: [{
             title: "Section 1 Row 1",
-            key: :section1_row1
+            tag: :section1_row1
           }, {
             title: "Section 1 Row 2",
-            key: :section1_row2
+            tag: :section1_row2
           }]
         }, {
           rows: [{
             title: "Section 2 Row 1",
-            key: :section2_row1
+            tag: :section2_row1
           }]
         }]
       }]
     })
 
-    menu.update(:section1_row2, {
+    menu.reconfigure(:section1_row2, {
       title: "New Title"
     })
 
     menu.itemAtIndex(0).submenu.itemAtIndex(1).title.should.equal "New Title"
   end
 
-  it "Updates the target and action of the menu item with the given key" do
+  it "Reconfigures the target and action of the menu item with the given tag" do
     class Dummy
       attr_accessor :action_completed
 
@@ -213,31 +213,92 @@ describe "MenuMotion::Menu" do
     menu = MenuMotion::Menu.new({
       rows: [{
         title: "Menu item",
-        key: :main_item,
+        tag: :main_item,
         sections: [{
           rows: [{
             title: "Section 1 Row 1",
-            key: :section1_row1
+            tag: :section1_row1
           }, {
             title: "Section 1 Row 2",
-            key: :section1_row2
+            tag: :section1_row2
           }]
         }, {
           rows: [{
             title: "Section 2 Row 1",
-            key: :section2_row1
+            tag: :section2_row1
           }]
         }]
       }]
     })
 
-    menu.update(:main_item, {
+    menu.reconfigure(:main_item, {
       target: dummy,
       action: "dummy_action"
     })
 
     menu.performActionForItemAtIndex(0)
     dummy.action_completed.should.equal true
+  end
+
+  it "Takes key shortcuts" do
+    menu = MenuMotion::Menu.new({
+                                  rows: [{
+                                           title: "Menu item",
+                                           tag: :main_item,
+                                           sections: [{
+                                                        rows: [{
+                                                                 title: "Section 1 Row 1",
+                                                                 tag: :section1_row1,
+                                                                 shortcut: "cmd+a"
+                                                               }, {
+                                                                 title: "Section 1 Row 2",
+                                                                 tag: :section1_row2
+                                                               }]
+                                                      }, {
+                                                        rows: [{
+                                                                 title: "Section 2 Row 1",
+                                                                 tag: :section2_row1
+                                                               }]
+                                                      }]
+                                         }]
+                                })
+
+    item = menu.item_with_tag(:section1_row1)
+    item.keyEquivalent.should.equal 'a'
+    item.keyEquivalentModifierMask.should.equal NSCommandKeyMask
+  end
+
+  it "Validates" do
+    validated = false
+
+    menu = MenuMotion::Menu.new({
+                                  rows: [{
+                                           title: "Menu item",
+                                           tag: :main_item,
+                                           sections: [{
+                                                        rows: [{
+                                                                 title: "Section 1 Row 1",
+                                                                 tag: :section1_row1,
+                                                                 validate: ->(mi) {
+                                                                   validated = true
+                                                                   false
+                                                                 }
+                                                               }, {
+                                                                 title: "Section 1 Row 2",
+                                                                 tag: :section1_row2
+                                                               }]
+                                                      }, {
+                                                        rows: [{
+                                                                 title: "Section 2 Row 1",
+                                                                 tag: :section2_row1
+                                                               }]
+                                                      }]
+                                         }]
+                                })
+
+    item = menu.item_with_tag(:section1_row1)
+    item.validate.should.equal false
+    validated.should.equal true
   end
 
 end


### PR DESCRIPTION
Interested in your thoughts on my changes/additions. I didn't update the README or specs, but will do so if we can converge on something like these:
- change :key to :tag in order to use :key for the keyboard shortcut
- add keyboard shortcuts as a string
- add :validate in order to support validateMenuItem
- :target defaults to NSApp
- change MenuMotion::Menu update method to reconfig in order to not collide with NSMenu's update method

E.g.

```
{
  title: SHAPE_AXES_MENU_TITLE,
  target: self,
  action: :_static_axes,
  tag: :shape_axes,
  key: 'shift-cmd-y',
  validate: ->(mi) {
    mi.title = (@shape_view.axesStatic ?
                SHAPE_AXES_MENU_TITLE :
                STATIC_AXES_MENU_TITLE)
    @shape_view.axesVisible
  }
}                                               
```
