### PR TITLE
Version 0.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    menu-motion (0.0.2)
+    menu-motion (0.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    menu_motion (0.0.1)
+    menu-motion (0.0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -47,7 +47,7 @@ PLATFORMS
 DEPENDENCIES
   awesome_print_motion
   guard-motion
-  menu_motion!
+  menu-motion!
   motion-redgreen
   rake
   terminal-notifier-guard

--- a/README.md
+++ b/README.md
@@ -140,35 +140,9 @@ def action_with_sender(sender)
 end
 ```
 
-### Keyboard shortcuts
+### Menu Item Validation
 
-Assign keyboard shortcuts to menu items. Takes a string of the form '(_modifier_+)*character' where _modifier_ is any of: shift, alt, alternate, command, cmd, control, ctrl, ctl.
-
-```ruby
-menu = MenuMotion::Menu.new({
-  rows: [{
-    title: "Menu item",
-    tag: :main_item
-    rows: [{
-      title: "Submenu item 1",
-      tag: :submenu_item1,
-      target: self,
-      action: "do_something:",
-      shortcut: "cmd+1"
-    }, {
-      title: "Submenu item 2",
-      tag: :submenu_item2,
-      target: self,
-      action: "do_something:"
-      shortcut: "shift+cmd+2"
-    }]
-  }]
-})
-```
-
-### Menu Item validation
-
-MenuMotion implements the [NSMenuValidation](https://developer.apple.com/library/mac/documentation/cocoa/reference/applicationkit/Protocols/NSMenuValidation_Protocol/Reference/Reference.html) protocol. Pass a method name or a proc to a menu item:
+MenuMotion implements the [NSMenuValidation](https://developer.apple.com/library/mac/documentation/cocoa/reference/applicationkit/Protocols/NSMenuValidation_Protocol/Reference/Reference.html) protocol. Pass a proc to a menu item on `validate`:
 
 ```ruby
 menu = MenuMotion::Menu.new({
@@ -181,16 +155,16 @@ menu = MenuMotion::Menu.new({
       target: self,
       action: "do_something:",
       validate: ->(menu_item) {
-        true
+        true # or false
       }
     }]
   }]
 })
 ```
 
-### Reconfiguring Menu Items
+### Updating Menu Items
 
-Assign tags to menu items that will need to be reconfigured.
+Assign tags to menu items that will need to be updated.
 
 ```ruby
 menu = MenuMotion::Menu.new({
@@ -211,7 +185,7 @@ menu = MenuMotion::Menu.new({
   }]
 })
 
-# Let's reconfigure the first item's title:
+# Let's update the first item's title:
 menu.update_item_with_tag(:main_item, {
   title: "Hello World"
 })
@@ -230,6 +204,7 @@ menu.update_item_with_tag(:submenu_item1, {
 ## TODO
 
 - Menu Item Icons
+- Keyboard Shortcuts
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -212,13 +212,13 @@ menu = MenuMotion::Menu.new({
 })
 
 # Let's reconfigure the first item's title:
-menu.reconfigure(:main_item, {
+menu.update_item_with_tag(:main_item, {
   title: "Hello World"
 })
 
 # And give the first submenu item a submenu.
 # The target and action will not be used if a submenu is defined.
-menu.reconfigure(:submenu_item1, {
+menu.update_item_with_tag(:submenu_item1, {
   rows: [{
     title: "Click me",
     target: self,

--- a/README.md
+++ b/README.md
@@ -70,12 +70,10 @@ menu = MenuMotion::Menu.new({
   }, {
     rows: [{
       title: "About MenuMotion",
-      target: self,
-      action: "about"
+      action: "orderFrontStandardAboutPanel:"
     }, {
       title: "Quit",
-      target: self,
-      action: "quit"
+      action: "terminate:"
     }]
   }]
 })
@@ -140,7 +138,7 @@ def action_with_sender(sender)
 end
 ```
 
-### Menu Item Validation
+### Validation
 
 MenuMotion implements the [NSMenuValidation](https://developer.apple.com/library/mac/documentation/cocoa/reference/applicationkit/Protocols/NSMenuValidation_Protocol/Reference/Reference.html) protocol. Pass a proc to a menu item on `validate`:
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ end
 
 ### Keyboard shortcuts
 
-Assign keyboard shortcuts to menu items. Takes a string of the form '(_modifier_+)*_character' where _modifier is any of: shift, alt, alternate, command, cmd, control, ctrl, ctl.
+Assign keyboard shortcuts to menu items. Takes a string of the form '(_modifier_+)*character' where _modifier_ is any of: shift, alt, alternate, command, cmd, control, ctrl, ctl.
 
 ```ruby
 menu = MenuMotion::Menu.new({
@@ -164,6 +164,7 @@ menu = MenuMotion::Menu.new({
     }]
   }]
 })
+```
 
 ### Menu Item validation
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,30 @@ def action_with_sender(sender)
 end
 ```
 
+### Keyboard Shortcuts
+
+Keyboard shortcuts can be assigned to menu items with a simple string.
+The string can include multiple modifier keys, followed by the final key to be assigned (`{modifier+}{modifier+}{key}`):
+
+```ruby
+menu = MenuMotion::Menu.new({
+  rows: [{
+    title: "Item 1",
+    shortcut: "command+1"
+  }, {
+    title: "Item 2",
+    shortcut: "control+shift+2"
+  }]
+})
+```
+
+#### Modifier Key Options
+
+- **`shift`**
+- **`control`**, `ctl`, `ctrl`
+- **`option`**, `opt`, `alt`, `alternate`
+- **`command`**, `cmd`
+
 ### Validation
 
 MenuMotion implements the [NSMenuValidation](https://developer.apple.com/library/mac/documentation/cocoa/reference/applicationkit/Protocols/NSMenuValidation_Protocol/Reference/Reference.html) protocol. Pass a proc to a menu item on `validate`:

--- a/README.md
+++ b/README.md
@@ -140,37 +140,84 @@ def action_with_sender(sender)
 end
 ```
 
-### Updating Menu Items
+### Keyboard shortcuts
 
-Assign keys to menu items that will need to be updated.
+Assign keyboard shortcuts to menu items. Takes a string of the form '(_modifier_+)*_character' where _modifier is any of: shift, alt, alternate, command, cmd, control, ctrl, ctl.
 
 ```ruby
 menu = MenuMotion::Menu.new({
   rows: [{
     title: "Menu item",
-    key: :main_item
+    tag: :main_item
     rows: [{
       title: "Submenu item 1",
-      key: :submenu_item1,
+      tag: :submenu_item1,
+      target: self,
+      action: "do_something:",
+      shortcut: "cmd+1"
+    }, {
+      title: "Submenu item 2",
+      tag: :submenu_item2,
+      target: self,
+      action: "do_something:"
+      shortcut: "shift+cmd+2"
+    }]
+  }]
+})
+
+### Menu Item validation
+
+MenuMotion implements the [NSMenuValidation](https://developer.apple.com/library/mac/documentation/cocoa/reference/applicationkit/Protocols/NSMenuValidation_Protocol/Reference/Reference.html) protocol. Pass a method name or a proc to a menu item:
+
+```ruby
+menu = MenuMotion::Menu.new({
+  rows: [{
+    title: "Menu item",
+    tag: :main_item
+    rows: [{
+      title: "Submenu item 1",
+      tag: :submenu_item1,
+      target: self,
+      action: "do_something:",
+      validate: ->(menu_item) {
+        true
+      }
+    }]
+  }]
+})
+```
+
+### Reconfiguring Menu Items
+
+Assign tags to menu items that will need to be reconfigured.
+
+```ruby
+menu = MenuMotion::Menu.new({
+  rows: [{
+    title: "Menu item",
+    tag: :main_item
+    rows: [{
+      title: "Submenu item 1",
+      tag: :submenu_item1,
       target: self,
       action: "do_something:"
     }, {
       title: "Submenu item 2",
-      key: :submenu_item2,
+      tag: :submenu_item2,
       target: self,
       action: "do_something:"
     }]
   }]
 })
 
-# Let's update the first item's title:
-menu.update(:main_item, {
+# Let's reconfigure the first item's title:
+menu.reconfigure(:main_item, {
   title: "Hello World"
 })
 
 # And give the first submenu item a submenu.
 # The target and action will not be used if a submenu is defined.
-menu.update(:submenu_item1, {
+menu.reconfigure(:submenu_item1, {
   rows: [{
     title: "Click me",
     target: self,
@@ -182,7 +229,6 @@ menu.update(:submenu_item1, {
 ## TODO
 
 - Menu Item Icons
-- Keyboard Shortcuts
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,4 +13,5 @@ end
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
   app.name = "MenuMotion"
+  app.info_plist["NSHumanReadableCopyright"] = "Copyright © 2014 Brian Pattison. All rights reserved."
 end

--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -39,6 +39,7 @@ class AppDelegate
         }]
       }]
     })
+
     status_item.setMenu(menu)
   end
 

--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -12,11 +12,13 @@ class AppDelegate
               rows: [{
                 title: "First Action",
                 target: self,
-                action: "first_action"
+                action: "first_action",
+                shortcut: "command+f"
               }, {
                 title: "Second Action",
                 target: self,
-                action: "action_with_sender:"
+                action: "action_with_sender:",
+                shortcut: "cmd+option+s"
               }]
             }]
           }, {

--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -30,12 +30,10 @@ class AppDelegate
       }, {
         rows: [{
           title: "About MenuMotion",
-          target: self,
-          action: "about"
+          action: "orderFrontStandardAboutPanel:"
         }, {
           title: "Quit",
-          target: self,
-          action: "quit"
+          action: "terminate:"
         }]
       }]
     })

--- a/lib/menu_motion/menu.rb
+++ b/lib/menu_motion/menu.rb
@@ -50,7 +50,11 @@ module MenuMotion
     end
 
     def initialize(params = {}, root_menu = nil)
-      initWithTitle(params[:title] || 'Add A Title!')
+      if params[:title]
+        initWithTitle(params[:title])
+      else
+        super()
+      end
 
       self.root_menu = root_menu
       self.build_menu_from_params(self, params)

--- a/lib/menu_motion/menu.rb
+++ b/lib/menu_motion/menu.rb
@@ -39,12 +39,12 @@ module MenuMotion
           menu_item.tag = tag
         end
 
-        if (ke=row[:key])
-          parts = ke.split('-')
+        if (ke=row[:shortcut])
+          parts = ke.split('+')
           k = parts.pop
 
-          raise MMException.new("Missing key char for menu item #{menu_item.title}: #{ke}") unless (k)
-          raise MMException.new("Unknown key char for menu item #{menu_item.title}: #{ke}") unless (k.length == 1)
+          raise MMException.new("Missing key char for menu item #{menu_item.title} shortcut: #{ke}") unless (k)
+          raise MMException.new("Unknown key char for menu item #{menu_item.title} shortcut: #{ke}") unless (k.length == 1)
 
           mod_mask = parts.inject(0) do |mask,mod|
             case mod
@@ -57,7 +57,7 @@ module MenuMotion
             when 'control', 'ctl', 'ctrl'
               mask |= NSControlKeyMask
             else
-              raise MMException.new("Unknown key modifier for menu item #{menu_item.title}: #{mod.to_s}. Want any of shift, alt, alternate, command, cmd, control, ctrl, ctl")
+              raise MMException.new("Unknown key modifier for menu item #{menu_item.title} shortcut: #{mod.to_s}. Want any of: shift, alt, alternate, command, cmd, control, ctrl, ctl")
             end
 
             mask
@@ -110,7 +110,7 @@ module MenuMotion
       @menu_items[tag.to_sym]
     end
 
-    def reconfig(tag, params)
+    def reconfigure(tag, params)
       menu_item = self.item_with_tag(tag)
 
       [
@@ -119,7 +119,7 @@ module MenuMotion
        :action,
        :validate,
        :tag,
-       :key,
+       :shortcut,
        :enabled
       ].each do |f|
         menu_item.send("#{f}=",params[f]) if (params.has_key?(f))

--- a/lib/menu_motion/menu.rb
+++ b/lib/menu_motion/menu.rb
@@ -2,31 +2,18 @@ module MenuMotion
 
   class Menu < NSMenu
 
-    attr_accessor :menu_items
-    attr_accessor :root_menu
-    attr_accessor :tag
+    attr_accessor :menu_items, :root_menu
 
     def add_rows_to_menu(menu, rows)
       rows.each do |row|
-        menu_item = MenuMotion::MenuItem.new(row[:title], row[:target], row[:action], row[:validate])
+        row[:root_menu] = WeakRef.new(self.root_menu || self)
+        menu_item = MenuMotion::MenuItem.new(row)
         menu_item.target = self
-        menu_item.action = '_menu_item_action:'
+        menu_item.action = "perform_action:"
 
-        # Add sections and/or rows to a submenu
-        if row[:sections]
-          submenu = MenuMotion::Menu.new({
-                                           sections: row[:sections]
-                                         }, self.root_menu || self)
-          menu_item.setSubmenu(submenu)
-        elsif row[:rows]
-          submenu = MenuMotion::Menu.new({
-                                           rows: row[:rows]
-                                         }, self.root_menu || self)
-          menu_item.setSubmenu(submenu)
-        end
-
-        if (tag=row[:tag])
+        if tag = row[:tag]
           tag = tag.to_sym
+          menu_item.tag = tag
 
           if self.root_menu
             self.root_menu.menu_items ||= {}
@@ -35,44 +22,10 @@ module MenuMotion
             self.menu_items ||= {}
             self.menu_items[tag] = WeakRef.new(menu_item)
           end
-
-          menu_item.tag = tag
-        end
-
-        if (ke=row[:shortcut])
-          parts = ke.split('+')
-          k = parts.pop
-
-          raise MMException.new("Missing key char for menu item #{menu_item.title} shortcut: #{ke}") unless (k)
-          raise MMException.new("Unknown key char for menu item #{menu_item.title} shortcut: #{ke}") unless (k.length == 1)
-
-          mod_mask = parts.inject(0) do |mask,mod|
-            case mod
-            when 'shift'
-              mask |= NSShiftKeyMask
-            when 'alt', 'alternate'
-              mask |= NSAlternateKeyMask
-            when 'command', 'cmd'
-              mask |= NSCommandKeyMask
-            when 'control', 'ctl', 'ctrl'
-              mask |= NSControlKeyMask
-            else
-              raise MMException.new("Unknown key modifier for menu item #{menu_item.title} shortcut: #{mod.to_s}. Want any of: shift, alt, alternate, command, cmd, control, ctrl, ctl")
-            end
-
-            mask
-          end
-
-          menu_item.setKeyEquivalent(k)
-          menu_item.setKeyEquivalentModifierMask(mod_mask)
         end
 
         menu.addItem(menu_item)
       end
-    end
-
-    def validateMenuItem(menu_item)
-      menu_item.validate
     end
 
     def add_sections_to_menu(menu, sections)
@@ -110,70 +63,19 @@ module MenuMotion
       @menu_items[tag.to_sym]
     end
 
-    def reconfigure(tag, params)
+    def perform_action(menu_item)
+      menu_item.perform_action
+    end
+
+    def update_item_with_tag(tag, params)
       menu_item = self.item_with_tag(tag)
-
-      [
-       :title,
-       :target,
-       :action,
-       :validate,
-       :tag,
-       :shortcut,
-       :enabled
-      ].each do |f|
-        menu_item.send("#{f}=",params[f]) if (params.has_key?(f))
-      end
-
-      self
+      menu_item.update(params)
     end
 
-    def _menu_item_action(menu_item)
-      menu_item.act
+    def validateMenuItem(menu_item)
+      menu_item.valid?
     end
 
   end
 
-  class MenuItem < NSMenuItem
-
-    attr_accessor :tag
-
-    def initialize(title, target, action, validate)
-      initWithTitle(title, action: nil, keyEquivalent: '')
-
-      @mi_validate = validate
-      @mi_target = target
-      @mi_action = action
-      self
-    end
-
-    def act
-      target = @mi_target || NSApp
-
-      if (@mi_action)
-        if (target.class.instance_method(@mi_action).arity == 0)
-          target.send(@mi_action) 
-        else
-          target.send(@mi_action,self)
-        end
-      end
-    end
-
-    def validate
-      if (@mi_validate.kind_of?(Proc))
-        return true unless (@mi_validate)
-
-        @mi_validate.call(self)
-      else
-        return true unless (@mi_validate && @mi_target)
-
-        @mi_target.send(@mi_validate,self)
-      end
-    end
-
-  end
-
-  class MMException < ::Exception
-  end
 end
-

--- a/lib/menu_motion/menu.rb
+++ b/lib/menu_motion/menu.rb
@@ -4,37 +4,75 @@ module MenuMotion
 
     attr_accessor :menu_items
     attr_accessor :root_menu
+    attr_accessor :tag
 
     def add_rows_to_menu(menu, rows)
       rows.each do |row|
-        menu_item = NSMenuItem.alloc.initWithTitle(row[:title], action: row[:action], keyEquivalent:"")
-        menu_item.target = row[:target]
+        menu_item = MenuMotion::MenuItem.new(row[:title], row[:target], row[:action], row[:validate])
+        menu_item.target = self
+        menu_item.action = '_menu_item_action:'
 
         # Add sections and/or rows to a submenu
         if row[:sections]
           submenu = MenuMotion::Menu.new({
-            sections: row[:sections]
-          }, self.root_menu || self)
+                                           sections: row[:sections]
+                                         }, self.root_menu || self)
           menu_item.setSubmenu(submenu)
         elsif row[:rows]
           submenu = MenuMotion::Menu.new({
-            rows: row[:rows]
-          }, self.root_menu || self)
+                                           rows: row[:rows]
+                                         }, self.root_menu || self)
           menu_item.setSubmenu(submenu)
         end
 
-        if row[:key]
+        if (tag=row[:tag])
+          tag = tag.to_sym
+
           if self.root_menu
             self.root_menu.menu_items ||= {}
-            self.root_menu.menu_items[row[:key].to_sym] = WeakRef.new(menu_item)
+            self.root_menu.menu_items[tag] = WeakRef.new(menu_item)
           else
             self.menu_items ||= {}
-            self.menu_items[row[:key].to_sym] = WeakRef.new(menu_item)
+            self.menu_items[tag] = WeakRef.new(menu_item)
           end
+
+          menu_item.tag = tag
+        end
+
+        if (ke=row[:key])
+          parts = ke.split('-')
+          k = parts.pop
+
+          raise MMException.new("Missing key char for menu item #{menu_item.title}: #{ke}") unless (k)
+          raise MMException.new("Unknown key char for menu item #{menu_item.title}: #{ke}") unless (k.length == 1)
+
+          mod_mask = parts.inject(0) do |mask,mod|
+            case mod
+            when 'shift'
+              mask |= NSShiftKeyMask
+            when 'alt', 'alternate'
+              mask |= NSAlternateKeyMask
+            when 'command', 'cmd'
+              mask |= NSCommandKeyMask
+            when 'control', 'ctl', 'ctrl'
+              mask |= NSControlKeyMask
+            else
+              raise MMException.new("Unknown key modifier for menu item #{menu_item.title}: #{mod.to_s}. Want any of shift, alt, alternate, command, cmd, control, ctrl, ctl")
+            end
+
+            mask
+          end
+
+          menu_item.setKeyEquivalent(k)
+          menu_item.setKeyEquivalentModifierMask(mod_mask)
         end
 
         menu.addItem(menu_item)
       end
+    end
+
+    def validateMenuItem(menu_item)
+      menu_item.validate
     end
 
     def add_sections_to_menu(menu, sections)
@@ -59,7 +97,7 @@ module MenuMotion
     end
 
     def initialize(params = {}, root_menu = nil)
-      super()
+      initWithTitle(params[:title] || 'Add A Title!')
 
       self.root_menu = root_menu
       self.build_menu_from_params(self, params)
@@ -67,22 +105,75 @@ module MenuMotion
       self
     end
 
-    def item_with_key(key)
+    def item_with_tag(tag)
       @menu_items ||= {}
-      @menu_items[key.to_sym]
+      @menu_items[tag.to_sym]
     end
 
-    def update(key, params)
-      menu_item = self.item_with_key(key)
+    def reconfig(tag, params)
+      menu_item = self.item_with_tag(tag)
 
-      menu_item.title  = params[:title]  if params[:title]
-      menu_item.target = params[:target] if params[:target]
-      menu_item.action = params[:action] if params[:action]
+      [
+       :title,
+       :target,
+       :action,
+       :validate,
+       :tag,
+       :key,
+       :enabled
+      ].each do |f|
+        menu_item.send("#{f}=",params[f]) if (params.has_key?(f))
+      end
 
       self
     end
 
+    def _menu_item_action(menu_item)
+      menu_item.act
+    end
+
   end
 
+  class MenuItem < NSMenuItem
+
+    attr_accessor :tag
+
+    def initialize(title, target, action, validate)
+      initWithTitle(title, action: nil, keyEquivalent: '')
+
+      @mi_validate = validate
+      @mi_target = target
+      @mi_action = action
+      self
+    end
+
+    def act
+      target = @mi_target || NSApp
+
+      if (@mi_action)
+        if (target.class.instance_method(@mi_action).arity == 0)
+          target.send(@mi_action) 
+        else
+          target.send(@mi_action,self)
+        end
+      end
+    end
+
+    def validate
+      if (@mi_validate.kind_of?(Proc))
+        return true unless (@mi_validate)
+
+        @mi_validate.call(self)
+      else
+        return true unless (@mi_validate && @mi_target)
+
+        @mi_target.send(@mi_validate,self)
+      end
+    end
+
+  end
+
+  class MMException < ::Exception
+  end
 end
 

--- a/lib/menu_motion/menu_item.rb
+++ b/lib/menu_motion/menu_item.rb
@@ -1,0 +1,77 @@
+module MenuMotion
+
+  class MenuItem < NSMenuItem
+
+    attr_accessor :item_action, :item_target,
+                  :root_menu, :tag, :validate
+
+    def initialize(params = {})
+      super()
+      update(params)
+      self
+    end
+
+    def perform_action
+      if self.valid? && self.valid_target_and_action?
+        if self.item_action.to_s.end_with?(":")
+          self.item_target.performSelector(self.item_action, withObject: self)
+        else
+          self.item_target.performSelector(self.item_action)
+        end
+      end
+    end
+
+    def update(params)
+      self.item_action = params[:action]    if params.has_key?(:action)
+      self.item_target = params[:target]    if params.has_key?(:target)
+      self.root_menu   = params[:root_menu] if params.has_key?(:root_menu)
+      self.title       = params[:title]     if params.has_key?(:title)
+      self.validate    = params[:validate]  if params.has_key?(:validate)
+
+      # Set NSApp as the default target if no other target is given
+      if self.item_action && self.item_target.nil?
+        self.item_target = NSApp
+      end
+
+      # Add sections and/or rows to a submenu
+      add_submenu_from_params(params)
+
+      self
+    end
+
+    def valid?
+      if self.submenu || self.valid_target_and_action?
+        if self.validate.nil?
+          true
+        else
+          self.validate.call(self)
+        end
+      else
+        false
+      end
+    end
+
+    def valid_target_and_action?
+      self.item_target && self.item_action && self.item_target.respond_to?(self.item_action.gsub(":", ""))
+    end
+
+  private
+
+    def add_submenu_from_params(params)
+      if params[:sections]
+        submenu = MenuMotion::Menu.new({
+          sections: params[:sections]
+        }, self.root_menu)
+        self.setSubmenu(submenu)
+      elsif params[:rows]
+        submenu = MenuMotion::Menu.new({
+          rows: params[:rows]
+        }, self.root_menu)
+        self.setSubmenu(submenu)
+      end
+    end
+
+  end
+
+end
+

--- a/lib/menu_motion/menu_item.rb
+++ b/lib/menu_motion/menu_item.rb
@@ -33,8 +33,9 @@ module MenuMotion
         self.item_target = NSApp
       end
 
-      # Add sections and/or rows to a submenu
-      add_submenu_from_params(params)
+      # Setup submenu and keyboard shortcut
+      set_submenu_from_params(params)
+      set_keyboard_shortcut(params[:shortcut]) if params.has_key?(:shortcut)
 
       self
     end
@@ -57,7 +58,35 @@ module MenuMotion
 
   private
 
-    def add_submenu_from_params(params)
+    def set_keyboard_shortcut(shortcut)
+      if shortcut
+        keys = shortcut.gsub("-", "+").split("+")
+        key = keys.pop
+        modifier_mask = 0
+        modifier_keys = keys
+
+        modifier_keys.each do |modifier_key|
+          case modifier_key
+          when "alt", "alternate", "opt", "option"
+            modifier_mask |= NSAlternateKeyMask
+          when "cmd", "command"
+            modifier_mask |= NSCommandKeyMask
+          when "ctl", "ctrl", "control"
+            modifier_mask |= NSControlKeyMask
+          when "shift"
+            modifier_mask |= NSShiftKeyMask
+          end
+        end
+
+        self.setKeyEquivalent(key)
+        self.setKeyEquivalentModifierMask(modifier_mask)
+      else
+        self.setKeyEquivalent(nil)
+        self.setKeyEquivalentModifierMask(nil)
+      end
+    end
+
+    def set_submenu_from_params(params)
       if params[:sections]
         submenu = MenuMotion::Menu.new({
           sections: params[:sections]

--- a/lib/menu_motion/version.rb
+++ b/lib/menu_motion/version.rb
@@ -1,3 +1,3 @@
 module MenuMotion
-  VERSION = "0.0.2"
+  VERSION = "0.1.0"
 end

--- a/spec/menu_motion/menu_item_spec.rb
+++ b/spec/menu_motion/menu_item_spec.rb
@@ -1,0 +1,82 @@
+describe "MenuMotion::MenuItem" do
+
+  it "should be defined" do
+    MenuMotion::MenuItem.is_a?(Class).should.equal true
+  end
+
+  it "should be an NSMenuItem" do
+    menu_item = MenuMotion::MenuItem.new
+    menu_item.is_a?(NSMenuItem).should.equal true
+  end
+
+  it "should accept a set of permitted attributes on initialization" do
+    dummy = Dummy.new
+
+    menu_item = MenuMotion::MenuItem.new({
+      title: "Hello World",
+      target: dummy,
+      action: "dummy_action"
+    })
+
+    menu_item.title.should.equal "Hello World"
+    menu_item.item_target.should.equal dummy
+    menu_item.item_action.should.equal "dummy_action"
+  end
+
+  it "#update should set permitted attributes on the menu item" do
+    dummy = Dummy.new
+
+    menu_item = MenuMotion::MenuItem.new({
+      title: "Hello World"
+    })
+
+    menu_item.update({
+      title: "What's up?",
+      target: dummy,
+      action: "dummy_action"
+    })
+
+    menu_item.title.should.equal "What's up?"
+    menu_item.item_target.should.equal dummy
+    menu_item.item_action.should.equal "dummy_action"
+  end
+
+  it "#perform_action should perform the action on the given target" do
+    dummy = Dummy.new
+
+    menu_item = MenuMotion::MenuItem.new({
+      title: "Hello",
+      target: dummy,
+      action: "dummy_action"
+    })
+
+    menu_item.perform_action
+    dummy.action_completed.should.equal true
+  end
+
+  it "#perform_action should send the menu item to the action if it ends with `:`" do
+    dummy = Dummy.new
+
+    menu_item = MenuMotion::MenuItem.new({
+      title: "Hello",
+      target: dummy,
+      action: "dummy_action_with_sender:"
+    })
+
+    menu_item.perform_action
+    dummy.sender.should.equal menu_item
+  end
+
+end
+
+class Dummy
+  attr_accessor :action_completed, :sender
+
+  def dummy_action
+    self.action_completed = true
+  end
+
+  def dummy_action_with_sender(sender)
+    self.sender = sender
+  end
+end

--- a/spec/menu_motion/menu_item_spec.rb
+++ b/spec/menu_motion/menu_item_spec.rb
@@ -15,30 +15,38 @@ describe "MenuMotion::MenuItem" do
     menu_item = MenuMotion::MenuItem.new({
       title: "Hello World",
       target: dummy,
-      action: "dummy_action"
+      action: "dummy_action",
+      shortcut: "cmd+h"
     })
 
     menu_item.title.should.equal "Hello World"
     menu_item.item_target.should.equal dummy
     menu_item.item_action.should.equal "dummy_action"
+    menu_item.keyEquivalent.should.equal "h"
+    menu_item.keyEquivalentModifierMask.should.equal NSCommandKeyMask
   end
 
   it "#update should set permitted attributes on the menu item" do
     dummy = Dummy.new
 
     menu_item = MenuMotion::MenuItem.new({
-      title: "Hello World"
+      title: "Hello World",
+      shortcut: "h"
     })
+    menu_item.keyEquivalent.should.equal "h"
 
     menu_item.update({
       title: "What's up?",
       target: dummy,
-      action: "dummy_action"
+      action: "dummy_action",
+      shortcut: "cmd-control-w"
     })
 
     menu_item.title.should.equal "What's up?"
     menu_item.item_target.should.equal dummy
     menu_item.item_action.should.equal "dummy_action"
+    menu_item.keyEquivalent.should.equal "w"
+    menu_item.keyEquivalentModifierMask.should.equal(NSCommandKeyMask | NSControlKeyMask)
   end
 
   it "#perform_action should perform the action on the given target" do

--- a/spec/menu_motion/menu_spec.rb
+++ b/spec/menu_motion/menu_spec.rb
@@ -135,71 +135,71 @@ describe "MenuMotion::Menu" do
     menu_item.submenu.itemAtIndex(3).title.should.equal "Section 2 Row 1"
   end
 
-  it "#item_with_key returns menu items by the lookup key" do
+  it "#item_with_tag returns menu items by the lookup tag" do
     menu = MenuMotion::Menu.new({
       rows: [{
         title: "Menu item",
-        key: :main_item,
+        tag: :main_item,
         sections: [{
           rows: [{
             title: "Section 1 Row 1",
-            key: :section1_row1
+            tag: :section1_row1
           }, {
             title: "Section 1 Row 2",
-            key: :section1_row2
+            tag: :section1_row2
           }]
         }, {
           rows: [{
             title: "Section 2 Row 1",
-            key: :section2_row1
+            tag: :section2_row1
           }]
         }]
       }]
     })
 
-    item = menu.item_with_key(:main_item)
+    item = menu.item_with_tag(:main_item)
     item.title.should.equal "Menu item"
 
-    item = menu.item_with_key(:section1_row1)
+    item = menu.item_with_tag(:section1_row1)
     item.title.should.equal "Section 1 Row 1"
 
-    item = menu.item_with_key(:section1_row2)
+    item = menu.item_with_tag(:section1_row2)
     item.title.should.equal "Section 1 Row 2"
 
-    item = menu.item_with_key(:section2_row1)
+    item = menu.item_with_tag(:section2_row1)
     item.title.should.equal "Section 2 Row 1"
   end
 
-  it "Updates the title of the menu item with the given key" do
+  it "Reconfigures the title of the menu item with the given tag" do
     menu = MenuMotion::Menu.new({
       rows: [{
         title: "Menu item",
-        key: :main_item,
+        tag: :main_item,
         sections: [{
           rows: [{
             title: "Section 1 Row 1",
-            key: :section1_row1
+            tag: :section1_row1
           }, {
             title: "Section 1 Row 2",
-            key: :section1_row2
+            tag: :section1_row2
           }]
         }, {
           rows: [{
             title: "Section 2 Row 1",
-            key: :section2_row1
+            tag: :section2_row1
           }]
         }]
       }]
     })
 
-    menu.update(:section1_row2, {
+    menu.reconfigure(:section1_row2, {
       title: "New Title"
     })
 
     menu.itemAtIndex(0).submenu.itemAtIndex(1).title.should.equal "New Title"
   end
 
-  it "Updates the target and action of the menu item with the given key" do
+  it "Reconfigures the target and action of the menu item with the given tag" do
     class Dummy
       attr_accessor :action_completed
 
@@ -213,31 +213,92 @@ describe "MenuMotion::Menu" do
     menu = MenuMotion::Menu.new({
       rows: [{
         title: "Menu item",
-        key: :main_item,
+        tag: :main_item,
         sections: [{
           rows: [{
             title: "Section 1 Row 1",
-            key: :section1_row1
+            tag: :section1_row1
           }, {
             title: "Section 1 Row 2",
-            key: :section1_row2
+            tag: :section1_row2
           }]
         }, {
           rows: [{
             title: "Section 2 Row 1",
-            key: :section2_row1
+            tag: :section2_row1
           }]
         }]
       }]
     })
 
-    menu.update(:main_item, {
+    menu.reconfigure(:main_item, {
       target: dummy,
       action: "dummy_action"
     })
 
     menu.performActionForItemAtIndex(0)
     dummy.action_completed.should.equal true
+  end
+
+  it "Takes key shortcuts" do
+    menu = MenuMotion::Menu.new({
+                                  rows: [{
+                                           title: "Menu item",
+                                           tag: :main_item,
+                                           sections: [{
+                                                        rows: [{
+                                                                 title: "Section 1 Row 1",
+                                                                 tag: :section1_row1,
+                                                                 shortcut: "cmd+a"
+                                                               }, {
+                                                                 title: "Section 1 Row 2",
+                                                                 tag: :section1_row2
+                                                               }]
+                                                      }, {
+                                                        rows: [{
+                                                                 title: "Section 2 Row 1",
+                                                                 tag: :section2_row1
+                                                               }]
+                                                      }]
+                                         }]
+                                })
+
+    item = menu.item_with_tag(:section1_row1)
+    item.keyEquivalent.should.equal 'a'
+    item.keyEquivalentModifierMask.should.equal NSCommandKeyMask
+  end
+
+  it "Validates" do
+    validated = false
+
+    menu = MenuMotion::Menu.new({
+                                  rows: [{
+                                           title: "Menu item",
+                                           tag: :main_item,
+                                           sections: [{
+                                                        rows: [{
+                                                                 title: "Section 1 Row 1",
+                                                                 tag: :section1_row1,
+                                                                 validate: ->(mi) {
+                                                                   validated = true
+                                                                   false
+                                                                 }
+                                                               }, {
+                                                                 title: "Section 1 Row 2",
+                                                                 tag: :section1_row2
+                                                               }]
+                                                      }, {
+                                                        rows: [{
+                                                                 title: "Section 2 Row 1",
+                                                                 tag: :section2_row1
+                                                               }]
+                                                      }]
+                                         }]
+                                })
+
+    item = menu.item_with_tag(:section1_row1)
+    item.validate.should.equal false
+    validated.should.equal true
   end
 
 end


### PR DESCRIPTION
Closes #1.
- Adds MotionMenu::MenuItem class
- Adds menu item validation
- Adds keyboard shortcuts
- Menu item lookup now uses `:tag` instead of `:key`
- MotionMenu::Menu#update was reverted back to original NSMenu#update
