### PR TITLE
NSMenuItem checkmarks

### DIFF
--- a/lib/menu-motion/core_ext/nsmenuitem.rb
+++ b/lib/menu-motion/core_ext/nsmenuitem.rb
@@ -5,6 +5,10 @@ class NSMenuItem
   end
 
   def checked=(value)
+    setChecked(value)
+  end
+
+  def setChecked(value)
     self.state = (value ? NSOnState : NSOffState)
   end
 end

--- a/lib/menu-motion/core_ext/nsmenuitem.rb
+++ b/lib/menu-motion/core_ext/nsmenuitem.rb
@@ -1,0 +1,10 @@
+# http://kickcode.com/blog/2013/11/07/rubymotion-background-process-in-status-bar-app.html
+class NSMenuItem
+  def checked?
+    self.state == NSOnState
+  end
+
+  def checked=(value)
+    self.state = (value ? NSOnState : NSOffState)
+  end
+end

--- a/lib/menu-motion/menu_item.rb
+++ b/lib/menu-motion/menu_item.rb
@@ -31,6 +31,7 @@ module MenuMotion
       self.root_menu   = params[:root_menu] if params.has_key?(:root_menu)
       self.title       = params[:title]     if params.has_key?(:title)
       self.validate    = params[:validate]  if params.has_key?(:validate)
+      self.checked     = params[:checked]   if params.has_key?(:checked)
 
       # Set NSApp as the default target if no other target is given
       if self.item_action && self.item_target.nil?

--- a/spec/menu_motion/menu_item_spec.rb
+++ b/spec/menu_motion/menu_item_spec.rb
@@ -17,7 +17,8 @@ describe "MenuMotion::MenuItem" do
       target: dummy,
       action: "dummy_action",
       shortcut: "cmd+h",
-      object: dummy
+      object: dummy,
+      checked: true
     })
 
     menu_item.title.should.equal "Hello World"
@@ -27,6 +28,7 @@ describe "MenuMotion::MenuItem" do
     menu_item.keyEquivalentModifierMask.should.equal NSCommandKeyMask
     menu_item.object.should.equal dummy
     menu_item.representedObject.should.equal dummy
+    menu_item.state.should.equal NSOnState
   end
 
   it "#update should set permitted attributes on the menu item" do
@@ -34,7 +36,8 @@ describe "MenuMotion::MenuItem" do
 
     menu_item = MenuMotion::MenuItem.new({
       title: "Hello World",
-      shortcut: "h"
+      shortcut: "h",
+      checked: true
     })
     menu_item.keyEquivalent.should.equal "h"
 
@@ -42,7 +45,8 @@ describe "MenuMotion::MenuItem" do
       title: "What's up?",
       target: dummy,
       action: "dummy_action",
-      shortcut: "cmd-control-w"
+      shortcut: "cmd-control-w",
+      checked: false
     })
 
     menu_item.title.should.equal "What's up?"
@@ -50,6 +54,7 @@ describe "MenuMotion::MenuItem" do
     menu_item.item_action.should.equal "dummy_action"
     menu_item.keyEquivalent.should.equal "w"
     menu_item.keyEquivalentModifierMask.should.equal(NSCommandKeyMask | NSControlKeyMask)
+    menu_item.state.should.equal NSOffState
   end
 
   it "#perform_action should perform the action on the given target" do

--- a/spec/menu_motion/nsmenuitem_spec.rb
+++ b/spec/menu_motion/nsmenuitem_spec.rb
@@ -4,11 +4,19 @@ describe "NSMenuItem Core Extensions" do
     @menu_item = NSMenuItem.new
   end
 
-  it 'should set checkmarks' do
+  it 'should set checkmarks with the = operator' do
     @menu_item.state.should.equal NSOffState
     @menu_item.checked = true
     @menu_item.state.should.equal NSOnState
     @menu_item.checked = false
+    @menu_item.state.should.equal NSOffState
+  end
+
+  it 'should set checkmarks with the setChecked method' do
+    @menu_item.state.should.equal NSOffState
+    @menu_item.setChecked true
+    @menu_item.state.should.equal NSOnState
+    @menu_item.setChecked false
     @menu_item.state.should.equal NSOffState
   end
 

--- a/spec/menu_motion/nsmenuitem_spec.rb
+++ b/spec/menu_motion/nsmenuitem_spec.rb
@@ -1,0 +1,21 @@
+describe "NSMenuItem Core Extensions" do
+
+  before do
+    @menu_item = NSMenuItem.new
+  end
+
+  it 'should set checkmarks' do
+    @menu_item.state.should.equal NSOffState
+    @menu_item.checked = true
+    @menu_item.state.should.equal NSOnState
+    @menu_item.checked = false
+    @menu_item.state.should.equal NSOffState
+  end
+
+  it 'should get the checked state as a boolean' do
+    @menu_item.checked?.should.equal false
+    @menu_item.checked = true
+    @menu_item.checked?.should.equal true
+  end
+
+end


### PR DESCRIPTION
Adds the ability to put this in your hash:

``` ruby
checked: true
```

to produce something like this:
![screenshot 2014-07-16 14 35 49](https://cloud.githubusercontent.com/assets/139261/3603561/0ad7dbdc-0d18-11e4-967d-f2a5b41f400f.png)

setting it to false and updating the menu clears the checkmark.

:sparkles: Fully tested! :sparkles: 
