### PR TITLE
Adds menuitem image capability with tests.

### DIFF
--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -31,6 +31,11 @@ class AppDelegate
         }]
       }, {
         rows: [{
+          title: "Image MenuItem",
+          image: "stopwatch"
+        }]
+      }, {
+        rows: [{
           title: "About MenuMotion",
           action: "orderFrontStandardAboutPanel:"
         }, {

--- a/lib/menu-motion/menu_item.rb
+++ b/lib/menu-motion/menu_item.rb
@@ -17,6 +17,11 @@ module MenuMotion
       self.state = (value ? NSOnState : NSOffState)
     end
 
+    def image=(i)
+      i = NSImage.imageNamed(i) unless i.is_a?(NSImage)
+      self.setImage(i)
+    end
+
     def initialize(params = {})
       super()
       update(params)
@@ -116,7 +121,7 @@ module MenuMotion
   private
 
     def assign_attributes(params)
-      [:checked, :object, :root_menu, :title, :validate].each do |key|
+      [:image, :checked, :object, :root_menu, :title, :validate].each do |key|
         self.send("#{key}=", params[key]) if params.has_key?(key)
       end
     end

--- a/spec/menu_motion/menu_item_spec.rb
+++ b/spec/menu_motion/menu_item_spec.rb
@@ -11,6 +11,7 @@ describe "MenuMotion::MenuItem" do
 
   it "should accept a set of permitted attributes on initialization" do
     dummy = Dummy.new
+    image = NSImage.imageNamed('stopwatch')
 
     menu_item = MenuMotion::MenuItem.new({
       title: "Hello World",
@@ -18,7 +19,8 @@ describe "MenuMotion::MenuItem" do
       action: "dummy_action",
       shortcut: "cmd+h",
       object: dummy,
-      checked: true
+      checked: true,
+      image: image
     })
 
     menu_item.title.should.equal "Hello World"
@@ -29,6 +31,7 @@ describe "MenuMotion::MenuItem" do
     menu_item.object.should.equal dummy
     menu_item.representedObject.should.equal dummy
     menu_item.state.should.equal NSOnState
+    menu_item.image.should.equal image
   end
 
   it "#update should set permitted attributes on the menu item" do
@@ -121,6 +124,24 @@ describe "MenuMotion::MenuItem" do
     menu_item.checked?.should.equal true
     menu_item.state = NSOffState
     menu_item.checked?.should.equal false
+  end
+
+  it "#image should set the NSMenuItem#image with a string" do
+    menu_item = MenuMotion::MenuItem.new
+
+    menu_item.image.should.equal nil
+    menu_item.image = 'stopwatch'
+    menu_item.image.should.not.equal nil
+    menu_item.image.class.should.equal NSImage
+  end
+
+  it "#image should set the NSMenuItem#image with a NSImage" do
+    menu_item = MenuMotion::MenuItem.new
+    image = NSImage.imageNamed('stopwatch')
+
+    menu_item.image.should.equal nil
+    menu_item.image = image
+    menu_item.image.should.equal image
   end
 
 end


### PR DESCRIPTION
This only adds `NSMenuItem.image` capability and ignores `onStateImage`, `offStateImage`, and `mixedStateImage` since the discussion of those API methods in the Apple docs say: `Changing state images is currently unsupported in OS X.`. Maybe you guys know more about this functionality than I do.

Closes #6.

Please note that this will cause a merge conflict with #18, so whichever you merge first, I'll update the other PR and fix the merge conflicts.
