### PR TITLE
workaround for build error

### DIFF
--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -58,7 +58,9 @@ class AppDelegate
 
   def status_item
     @status_item ||= begin
-      status_item = NSStatusBar.systemStatusBar.statusItemWithLength(NSSquareStatusItemLength).init
+      # Workaround for http://hipbyte.myjetbrains.com/youtrack/issue/RM-648
+      # -2 means NSSquareStatusItemLength
+      status_item = NSStatusBar.systemStatusBar.statusItemWithLength(-2).init
       status_item.setHighlightMode(true)
 
       status_image = NSImage.imageNamed("stopwatch.pdf")


### PR DESCRIPTION
When run "rake" on Yosemite, build error is occurred, like

```
$ rake
     Build ./build/MacOSX-10.10-Development
   Compile ./app/app_delegate.rb
      Link ./build/MacOSX-10.10-Development/menu.app/Contents/MacOS/menu
Undefined symbols for architecture x86_64:
  "_NSSquareStatusItemLength", referenced from:
      _MREP_FBAC5161392349B698908DFFEB2F205C in app_delegate.rb.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
rake aborted!
Command failed with status (1): [/usr/bin/clang++ -o "./build/MacOSX-10.10-...]
/Library/RubyMotion/lib/motion/project/builder.rb:320:in `build'
/Library/RubyMotion/lib/motion/project/app.rb:78:in `build'
/Library/RubyMotion/lib/motion/project/template/osx.rb:41:in `block (2 levels) in <top (required)>'
/Library/RubyMotion/lib/motion/project/template/osx.rb:59:in `block in <top (required)>'
Tasks: TOP => build:development
(See full trace by running task with --trace)
```

This is workaround for http://hipbyte.myjetbrains.com/youtrack/issue/RM-648
