### PR TITLE
Example app should support Yosemite dark mode.

### DIFF
--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -64,9 +64,11 @@ class AppDelegate
       status_item.setHighlightMode(true)
 
       status_image = NSImage.imageNamed("stopwatch.pdf")
+      status_image.setTemplate(true)
       status_item.setImage(status_image)
 
       alt_status_image = NSImage.imageNamed("stopwatch-alt.pdf")
+      alt_status_image.setTemplate(true)
       status_item.setAlternateImage(alt_status_image)
 
       status_item


### PR DESCRIPTION
We do this by setting the status images to template mode and when in dark mode, the image is automatically inverted for us. Pretty neat!
